### PR TITLE
Fix API tokens not working correctly

### DIFF
--- a/src/Exceptions/InvalidTokenException.php
+++ b/src/Exceptions/InvalidTokenException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace cbzink\LaunchLibrary\Exceptions;
+
+use Exception;
+
+class InvalidTokenException extends Exception
+{
+    /**
+     * Create a new exception instance.
+     */
+    public function __construct()
+    {
+        parent::__construct('Invalid token.');
+    }
+}

--- a/src/LL2.php
+++ b/src/LL2.php
@@ -54,14 +54,19 @@ class LL2
         $this->apiToken      = $apiToken;
         $this->apiEndpoint   = $apiEndpoint ?: 'https://ll.thespacedevs.com/2.2.0/';
 
+        $headers = [
+            'Accept'       => 'application/json',
+            'Content-Type' => 'application/json',
+        ];
+
+        if ($this->apiToken) {
+            $headers['Authorization'] = "Token {$this->apiToken}";
+        }
+
         $this->guzzle = $guzzle ?: new HttpClient([
             'base_uri'    => 'https://ll.thespacedevs.com/2.2.0/',
             'http_errors' => false,
-            'headers'     => [
-                'Token'        => $this->apiToken,
-                'Accept'       => 'application/json',
-                'Content-Type' => 'application/json',
-            ],
+            'headers'     => $headers,
         ]);
     }
 

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -6,6 +6,7 @@ use Exception;
 use GuzzleHttp\Psr7\Response;
 use cbzink\LaunchLibrary\Exceptions\NotFoundException;
 use cbzink\LaunchLibrary\Exceptions\RateLimitException;
+use cbzink\LaunchLibrary\Exceptions\InvalidTokenException;
 
 trait MakesHttpRequests
 {
@@ -78,6 +79,10 @@ trait MakesHttpRequests
      */
     protected function handleRequestError(Response $response): void
     {
+        if ($response->getStatusCode() === 401) {
+            throw new InvalidTokenException();
+        }
+
         if ($response->getStatusCode() === 429) {
             $body = json_decode((string) $response->getBody(), true);
 

--- a/tests/LL2Test.php
+++ b/tests/LL2Test.php
@@ -19,6 +19,7 @@ use cbzink\LaunchLibrary\Api\DockingEvent;
 use cbzink\LaunchLibrary\Api\SpaceStation;
 use cbzink\LaunchLibrary\Api\Launch\Launch;
 use cbzink\LaunchLibrary\Api\Spacecraft\Spacecraft;
+use cbzink\LaunchLibrary\Exceptions\InvalidTokenException;
 use cbzink\LaunchLibrary\Exceptions\NotFoundException;
 use cbzink\LaunchLibrary\Exceptions\RateLimitException;
 use cbzink\LaunchLibrary\Exceptions\UnknownApiException;
@@ -77,6 +78,22 @@ class LL2Test extends TestCase
             'id'   => 123,
             'name' => 'Test',
         ]);
+    }
+
+    public function testHandlesInvalidTokenErrors()
+    {
+        $this->expectException(InvalidTokenException::class);
+
+        $guzzle = Mockery::mock(HttpClient::class);
+        $client = new LL2(null, null, $guzzle);
+
+        $guzzle->shouldReceive('request')->once()->with('GET', 'agencies', [
+            'query' => ['limit' => $client->getPaginationLimit()],
+        ])->andReturn(
+            new Response(401, [], '{"detail": "Invalid token."}')
+        );
+
+        $client->get('agencies');
     }
 
     public function testHandlesRateLimitErrors()


### PR DESCRIPTION
# Changes

* Added `InvalidTokenException` when LL2 API returns an HTTP 401 error.

# Bug Fixes

* Fixed API tokens not working correctly.